### PR TITLE
Made editor space taller

### DIFF
--- a/public/css/pad.css
+++ b/public/css/pad.css
@@ -64,7 +64,7 @@ body {
 #editor {
     display: block;
     width: auto;
-    height: 600;
+    height: 90%;
 }
 
 #messages {


### PR DESCRIPTION
Not sure if you set the height the way you did for a reason, but 90% seems to work well for most screen sizes and gives way more editor real estate